### PR TITLE
Remove "e" from Berline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
-title: Berline.rs
+title: Berlin.rs
 description: "A Berlin-local Rust community"
 url: "http://berlin.rs"
 author:
-  name: Berline.rs 
+  name: Berlin.rs 
   twitter: rustberlin
   github: berlinrs
   meetup: Rust-Berlin

--- a/_posts/2016-09-16-rustfest-berlin.md
+++ b/_posts/2016-09-16-rustfest-berlin.md
@@ -9,4 +9,4 @@ location: msft-berlin
 
 In 2016, the Berlin Rust community, together with friends from [rust.cologne](https://rust.cologne) and the Kyiv community started the first European Rust conference. See the link for details on speakers and videos. RustFest happens every half year.
 
-Berline.rs continue to be part of the organisation of subsequent events.
+Berlin.rs continue to be part of the organisation of subsequent events.

--- a/about.md
+++ b/about.md
@@ -3,7 +3,7 @@ layout: page
 title: About
 ---
 
-Berline.rs is the website of the Berlin Rust Community. That is currently:
+Berlin.rs is the website of the Berlin Rust Community. That is currently:
 
 * The Rust Hack & Learn
 * The Rust Show & Tell


### PR DESCRIPTION
Not sure this is an error, but it sure looks confusing, especially considering `berline.rs` not being available nor leading to this page.

![screenshot-20180806120931-1405x271](https://user-images.githubusercontent.com/40496/43711269-739a51f0-9972-11e8-8abc-b0d1021291b6.png)
