### PR TITLE
activate feed plugin in GitHub pages.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Berline.rs
 description: "A Berlin-local Rust community"
 url: "http://berline.rs"
 author:
-  name: Berline.rs 
+  name: Berline.rs
   twitter: rustberlin
   github: berlinrs
   meetup: Rust-Berlin
@@ -26,6 +26,9 @@ defaults:
       type: "posts"
     values:
       layout: "event"
+
+plugins:
+  - jekyll-feed
 
 # Content settings
 future: true # we use dates for the actual meetup time, not the post publication time


### PR DESCRIPTION
Hi, seems that the RSS link is broken on the production:

https://berline.rs/feed.xml

I tried to fix the problem on my local at first but seems working well in development mode. So I think the problem is about GitHub Pages. I'm not sure if my PR will solve the problem exactly but here there is the same problem:

https://github.com/mmistakes/minimal-mistakes/issues/417#issuecomment-356746043

Regards.

